### PR TITLE
feat: Implementa a integração completa com Slack para notificações de novos cadastros.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-var ambiente_processo = 'desenvolvimento';
+var ambiente_processo = 'producao';
 
 var caminho_env = ambiente_processo === 'producao' ? '.env' : '.env.dev';
 

--- a/src/models/CadastroModel.js
+++ b/src/models/CadastroModel.js
@@ -31,8 +31,8 @@ function cadastrarEmpresaEFuncionario(empresa, usuario) {
       throw new Error('Falha ao obter o ID da nova empresa. Cadastro cancelado.');
     }
     var instrucaoSqlFuncionario = `
-            INSERT INTO Funcionario (nome, cpf, email, senha, fkTipoUsuario, fkEmpresa) 
-            VALUES ('${usuario.nome}', '${usuario.cpf}', '${usuario.email}', '${usuario.senha}',1000,${idNovaEmpresa});
+            INSERT INTO Funcionario (nome, cpf, email, senha, fkTipoUsuario, fkEmpresa, fkCriadoPor) 
+            VALUES ('${usuario.nome}', '${usuario.cpf}', '${usuario.email}', '${usuario.senha}',1000,${idNovaEmpresa}, 1);
         `;
     console.log('Executando SQL para Funcionário: \n' + instrucaoSqlFuncionario);
     return database.executar(instrucaoSqlFuncionario);
@@ -53,11 +53,22 @@ function buscarPorEmail(email) {
   console.log('Executando a instrução SQL: \n' + instrucaoSql);
   return database.executar(instrucaoSql);
 }
+function atualizarCanalSlack(idEmpresa, idCanalSlack, linkCanalSlack) {
+  console.log('ACESSEI O USUARIO MODEL para atualizar slcak:', idEmpresa, idCanalSlack, linkCanalSlack);
 
-// Não se esqueça de adicionar a nova função ao module.exports
+  var instrucaoSql = `
+        UPDATE Empresa SET idCanalSlack = '${idCanalSlack}', LinkCanalSlack = '${linkCanalSlack}', fkEditadoPor = 1 WHERE idEmpresa = ${idEmpresa} ;
+    `;
+  console.log('Executando a instrução SQL: \n' + instrucaoSql);
+  return database.executar(instrucaoSql);
+}
+
+
+
 module.exports = {
   autenticar,
   cadastrar: cadastrarEmpresaEFuncionario,
   verificarDuplicidade,
   buscarPorEmail,
+  atualizarCanalSlack
 };


### PR DESCRIPTION
Este Pull Request (PR) introduz a funcionalidade de integração com o Slack, conforme planejado. O objetivo principal é automatizar a criação de canais de alerta para novas empresas cadastradas e garantir que a nossa equipe de suporte e monitoramento seja adicionada imediatamente.

Alterações Principais:
Criação Dinâmica de Canais: Após o sucesso do finalizarCadastro, um novo canal é criado no Slack.

Nome do Canal: #alertas-[razao-social-formatada].

Visibilidade: O canal é criado como privado

Convite Automatizado de Membros Internos (Configuração Fixa):

O novo canal convida automaticamente os Bots Padrão e os Administradores Internos (da equipe de desenvolvimento/suporte).

Os IDs dos Bots (BOT_PADRAO_IDS) e os e-mails dos Administradores (ADMINS_PADRAO_EMAILS) são lidos das variáveis de ambiente (.env).

Nota: O administrador que acabou de se cadastrar (cliente) não é convidado, mantendo a visibilidade restrita à nossa equipe.

Atualização do Banco de Dados: O ID e o link do novo canal Slack são salvos na tabela Empresa.